### PR TITLE
Add sitemap.xml

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -10,6 +10,10 @@ const cookieName = 'i18next';
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
+  const url = new URL(req.url);
+  if (url.pathname === '/sitemap.xml') {
+    return NextResponse.redirect(new URL('/api/sitemap.xml', req.url));
+  }
   const userLanguage = getUserLanguage(req);
   const pathLanguage = getPathLanguage(req.nextUrl.pathname);
   if (!languages.includes(pathLanguage)) {

--- a/pages/api/sitemap.xml.ts
+++ b/pages/api/sitemap.xml.ts
@@ -1,0 +1,65 @@
+import { languages } from '#/lib/i18n/settings';
+import { getPosts } from '#/lib/posts';
+import { getURL } from '#/lib/utils';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const sitemap = await generateSiteMap();
+
+  res.setHeader('Content-Type', 'text/xml');
+  res.write(sitemap);
+  res.end();
+}
+
+async function generateSiteMap() {
+  const url = getURL();
+  // We expect that the home pages changes always, if we add a feed of latest articles, comments and nodes.
+  const homePages = languages
+    .map(
+      (language) =>
+        `
+      <url>
+        <loc>${url}${language}</loc>
+        <changefreq>always</changefreq>
+        <priority>1.00</priority>
+      </url>`,
+    )
+    .join('');
+  // The blogs will change daily on average
+  const blogPages = languages
+    .map(
+      (language) =>
+        `
+      <url>
+        <loc>${url}${language}/blog</loc>
+        <changefreq>daily</changefreq>
+        <priority>0.80</priority>
+      </url>`,
+    )
+    .join('');
+
+  // Posts change daily on average (including comments)
+  const posts = await getPosts();
+  const postPages = posts
+    .map(
+      (post) =>
+        `
+      <url>
+        <loc>${url}${post.language}/blog/${post.slug}</loc>
+        <changefreq>daily</changefreq>
+        <priority>0.64</priority>
+      </url>`,
+    )
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+     ${homePages}
+     ${blogPages}
+     ${postPages}
+   </urlset>
+ `;
+}


### PR DESCRIPTION
The sitemap.xml is available on `/api/sitemap.xml` (I am not sure how to create it with Next.js app directory on `/sitemap.xml`).
But I added a redirect from `/sitemap.xml` to `/api/sitemap.xml` which should work fine.

The sitemap includes the home pages, blog and posts in all languages.
User profiles are not included (I don't think we need them).

Later, we will add all the nodes on the map and items in the database.
