### PR TITLE
Optimized icons import

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,13 @@ const nextConfig = {
     // Required:
     appDir: true,
   },
+  // https://github.com/tabler/tabler-icons/issues/359
+  modularizeImports: {
+    '@tabler/icons-react': {
+      transform: '@tabler/icons-react/dist/esm/icons/{{member}}',
+    },
+  },
+  transpilePackages: ['@tabler/icons-react'],
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
I've noticed this, on one of my project.

When you're using @tabler/icons-react and importing icons it's actually importing and using the whole module.

Here is the [issue](https://github.com/tabler/tabler-icons/issues/359) the code is coming from.

Before:

![Before](https://user-images.githubusercontent.com/43091603/217348234-c5d76cb0-3251-46c4-9138-c2b5d7df30f1.png)

After:

![image](https://user-images.githubusercontent.com/43091603/217348388-c631138a-3b3a-4803-b99f-c3afdeccacbc.png)
